### PR TITLE
added a patch to run the engines specs in a local environment as GHA

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,35 @@ Very similar to the rules regarding when to restart a rails application
 - you changed anything docker-compose.yml file
 - you changed the Dockerfile of any container
 
+## Run the specs as Github Actions
+
+The IdeaCrew GHA runs the specs as "engines" that means it runs the specs for each component separately from the main enroll app. This can now be run under docker by following this method.
+
+1. start the containers
+```
+docker-compose up
+```
+
+2. open a shell on the running enroll
+```
+docker-compose exec enroll bash
+```
+
+3. go to the component you want to run the specs for example financial assitance
+```
+cd components/financial_assistance
+```
+
+4. bundle install
+```
+bundle install
+```
+
+5. run the specs
+```
+bundle exec rspec
+```
+
 ## Cucumber
 
 It is possible to run cucumber, however, there are 2 drawbacks; first is that the gem webdrivers have to be removed manually and the container restarted, and the second drawback is that it uses a "modified" env.rb that removes all the references to the webdriver gem, this is done automatically via a virtual volume on docker-compose (as end user you don't need to worry about this unless something big changes on cucumber).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,11 @@ services:
       - ${PWD}/hotpatches/cucumber_env.rb:/enroll/features/support/env.rb:ro
       - ${PWD}/hotpatches/mongoid-enroll.yml:/enroll/config/mongoid.yml:ro
       - ${PWD}/hotpatches/mongoid-enroll.yml:/enroll/components/financial_assistance/spec/dummy/config/mongoid.yml:ro
+      - ${PWD}/hotpatches/mongoid-enroll.yml:/enroll/components/benefit_markets/spec/dummy/config/mongoid.yml:ro
+      - ${PWD}/hotpatches/mongoid-enroll.yml:/enroll/components/notifier/spec/dummy/config/mongoid.yml:ro
+      - ${PWD}/hotpatches/mongoid-enroll.yml:/enroll/components/sponsored_benefits/spec/dummy/config/mongoid.yml:ro
+      - ${PWD}/hotpatches/mongoid-enroll.yml:/enroll/components/transport_profiles/spec/dummy/config/mongoid.yml:ro
+      - ${PWD}/hotpatches/mongoid-enroll.yml:/enroll/components/benefit_sponsors/spec/dummy/config/mongoid.yml:ro
       - enroll_node_modules_cache:/enroll/node_modules
       - enroll_packs_cache:/enroll/public/packs
       - enroll_rails_cache:/enroll/tmp/cache

--- a/hotpatches/cucumber_env.rb
+++ b/hotpatches/cucumber_env.rb
@@ -8,7 +8,7 @@
 
 ENV["RAILS_ENV"] ||= 'test'
 puts "------------------------------------------------------------------------"
-puts "RAILS_ENV: #{ENV["RAILS_ENV"]}"
+puts "RAILS_ENV: #{ENV['RAILS_ENV']}"
 puts "------------------------------------------------------------------------"
 puts "------------ THIS ENV FILE HAS BEEN HACKED BY DOCKER ! -----------------"
 puts "---------- see ea_enterprise README for more information ---------------"

--- a/hotpatches/cucumber_env.rb
+++ b/hotpatches/cucumber_env.rb
@@ -9,7 +9,16 @@
 ENV["RAILS_ENV"] ||= 'test'
 puts "------------------------------------------------------------------------"
 puts "RAILS_ENV: #{ENV["RAILS_ENV"]}"
+puts "------------------------------------------------------------------------"
+puts "------------ THIS ENV FILE HAS BEEN HACKED BY DOCKER ! -----------------"
+puts "---------- see ea_enterprise README for more information ---------------"
+
 $LOADING_CUCUMBER_ENV = true
+if ENV["COVERAGE"]
+  require 'simplecov'
+  SimpleCov.command_name "specs_#{Process.pid}_#{ENV['TEST_ENV_NUMBER'] || '1'}"
+  SimpleCov.start 'rails'
+end
 # require 'webdrivers'
 require 'cucumber/rails'
 require 'email_spec/cucumber'


### PR DESCRIPTION
Patch the engine's mongo configuration in the ea_enterprise. This will allow us to run the rspec as GitHub engines if needed, updated the readme on how to do this.

The cucumber file is to keep it in sync with enroll with the latest changes.